### PR TITLE
Fix behavior of "last" indicator

### DIFF
--- a/src/ringbuffer.rs
+++ b/src/ringbuffer.rs
@@ -3,13 +3,18 @@ use std::fmt::Debug;
 #[derive(Debug)]
 pub struct FixedRingBuffer<T> {
     buf: Vec<T>,
-    cap: usize,
-    head: usize,
+    cap: usize,     // Buffer size
+    head: usize,    // Index of most recent value
 }
 
 impl<T: Copy + Default> FixedRingBuffer<T> {
     pub fn new(capacity: usize) -> Self {
         Self {
+            /**
+             * Vector initialized with a capacity twice as high as the maximum number of elements
+             * displayed in the chart in order to always have all current values stored in one
+             * contiguous slice of the vector.
+             */
             buf: Vec::with_capacity(2 * capacity),
             cap: capacity,
             head: 0,
@@ -25,11 +30,13 @@ impl<T: Copy + Default> FixedRingBuffer<T> {
         // already reduced memory allocation with larger buffer
         if self.buf.len() == self.buf.capacity() {
             let len = self.buf.len();
+            // Overwrite older values by shifting left
             self.buf.copy_within(self.head + 1..len, 0);
+            // Truncate vector
             self.buf.resize(self.cap - 1, Default::default());
             self.head = 0;
         }
-        self.buf.push(elem);
+        // Append to back of vector
         if self.buf.len() > self.cap {
             self.head += 1;
         }
@@ -44,7 +51,8 @@ impl<T: Copy + Default> FixedRingBuffer<T> {
     }
 
     pub fn last(&self) -> &T {
-        &self.buf[self.head]
+        // New values are always appended to the end of the buffer
+        &self.buf[self.buf.len() - 1]
     }
 }
 

--- a/src/ringbuffer.rs
+++ b/src/ringbuffer.rs
@@ -10,8 +10,7 @@ pub struct FixedRingBuffer<T> {
 impl<T: Copy + Default> FixedRingBuffer<T> {
     pub fn new(capacity: usize) -> Self {
         Self {
-            /**
-             * Vector initialized with a capacity twice as high as the maximum number of elements
+            /* Vector initialized with a capacity twice as high as the maximum number of elements
              * displayed in the chart in order to always have all current values stored in one
              * contiguous slice of the vector.
              */
@@ -37,6 +36,7 @@ impl<T: Copy + Default> FixedRingBuffer<T> {
             self.head = 0;
         }
         // Append to back of vector
+        self.buf.push(elem);
         if self.buf.len() > self.cap {
             self.head += 1;
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -50,7 +50,7 @@ pub fn draw_ui<T: tui::backend::Backend>(
                 );
 
                 f.render_widget(
-                    Paragraph::new(format!("last {:?}", data_store.last(cmd_id) as u64))
+                    Paragraph::new(format!("current {:?}", data_store.last(cmd_id) as u64))
                         .style(style),
                     header_layout[1],
                 );


### PR DESCRIPTION
Indicator labeled "last" in top left corner now shows the most recent value instead of the oldest one.

Also, the label now reads "current" instead of "last" to remove ambiguity.

Fixes #14