### PR TITLE
More space for command display in top bar

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -34,11 +34,11 @@ pub fn draw_ui<T: tui::backend::Backend>(
                     .direction(Direction::Horizontal)
                     .constraints(
                         [
-                            Constraint::Percentage(20),
-                            Constraint::Percentage(20),
-                            Constraint::Percentage(20),
-                            Constraint::Percentage(20),
-                            Constraint::Percentage(20),
+                            Constraint::Percentage(40),
+                            Constraint::Percentage(15),
+                            Constraint::Percentage(15),
+                            Constraint::Percentage(15),
+                            Constraint::Percentage(15),
                         ]
                         .as_ref(),
                     )


### PR DESCRIPTION
Value indicators are pushed to the right and give twice as much space for commands, making it less likely that a command is truncated.

![image](https://github.com/aantn/smag/assets/39708242/b613d92b-2af2-4e59-be28-cae0f8be65d6)