### PR TITLE
Improve range calculation and tick spacing/placement

### DIFF
--- a/src/datastore.rs
+++ b/src/datastore.rs
@@ -14,7 +14,7 @@ pub struct DataStore {
 
 impl DataStore {
     pub fn new(args : Args) -> Self {
-	let host_count = args.cmds.len();
+        let host_count = args.cmds.len();
         DataStore {
             styles: (0..host_count)
                 .map(|i| Style::default().fg(Color::Indexed(i as u8 + 1)))
@@ -70,7 +70,7 @@ impl DataStore {
             self.window_max.iter().fold(0f64, |a, &b| a.max(b)),
         ]
     }
-    pub fn y_axis_bounds(&self) -> [f64; 2] {
+    pub fn y_axis_bounds(&self) -> ([f64; 2], i32) {
         let iter = self
             .data
             .iter()
@@ -78,11 +78,37 @@ impl DataStore {
             .flatten()
             .map(|v| v.1);
         let min = iter.clone().fold(f64::INFINITY, |a, b| a.min(b));
-        let max = iter.fold(0f64, |a, b| a.max(b));
-        // Add a 10% buffer to the top and bottom
-        let max_10_percent = (max * 10_f64) / 100_f64;
-        let min_10_percent = (min * 10_f64) / 100_f64;
-        [min - min_10_percent, max + max_10_percent]
+        let max = iter        .fold(0f64,          |a, b| a.max(b));
+        let range = max - min;
+
+        // Parameters for automatic range and tick placement algorithm
+        let preferred_num_ticks : i32 = 5;
+        let range_buffer_percent_per_side : f64 = 5.0;
+
+        // Calculate tick spacing by rounding the log10 of the preferred increment
+        let range_buffered = range + 2.0 * range_buffer_percent_per_side / 100.0;
+        let preferred_increment : f64 = range_buffered / (preferred_num_ticks - 1) as f64;
+        let log10_times3 : i32 = (preferred_increment.log10() * 3.0).round() as i32;
+        let exponent : i32 = log10_times3 / 3;
+        let mut increment : f64 = 10_f64.powf(exponent as f64).max(1.0);
+        // Adjust increment to a power-of-ten multiple of 1, 2 or 5
+        match log10_times3 % 3 {
+            0 => (),
+            1 => increment *= 2.0,
+            2 => increment *= 5.0,
+            _ => increment = 1.0,
+        }
+
+        // Add buffer and round out to multiples of increment
+        let range_buffer_per_side = if range > 0.0 {
+            range_buffer_percent_per_side / 100.0 * range
+        } else { 1.0 };
+        let min_round = ((min - range_buffer_per_side) / increment).floor() * increment;
+        let max_round = ((max + range_buffer_per_side) / increment).ceil()  * increment;
+        // Calculate number of ticks
+        let num_ticks : i32 = ((max_round - min_round) / increment).round() as i32 + 1;
+
+        ([min_round, max_round], num_ticks)
     }
 
     fn format_tick(&self, increment: f64, value: f64) -> String {
@@ -103,15 +129,13 @@ impl DataStore {
         }
     }
 
-    pub fn y_axis_labels(&self, bounds: [f64; 2]) -> Vec<Span> {
-	let ticks = 5;
+    pub fn y_axis_labels(&self, bounds: [f64; 2], num_ticks: i32) -> Vec<Span> {
         let min = bounds[0];
         let max = bounds[1];
 
-        let difference = max - min;
-        let increment = difference / (ticks as f64 - 1.0);
+        let increment = (max - min) / (num_ticks - 1) as f64;
 
-        (0..ticks)
+        (0..num_ticks)
             .map(|i| Span::raw(self.format_tick(increment, min + increment * i as f64) + " " + &self.args.y_label))
             .collect()
     }

--- a/src/datastore.rs
+++ b/src/datastore.rs
@@ -135,8 +135,16 @@ impl DataStore {
 
         let increment = (max - min) / (num_ticks - 1) as f64;
 
+        let y_label = &self.args.y_label;
+        let mut suffix = String::new();
+        suffix.push_str(" ");
+        if !y_label.is_empty() {
+            suffix.push_str(&y_label);
+            suffix.push_str(" ");
+        }
+
         (0..num_ticks)
-            .map(|i| Span::raw(self.format_tick(increment, min + increment * i as f64) + " " + &self.args.y_label))
+            .map(|i| Span::raw(self.format_tick(increment, min + increment * i as f64) + &suffix))
             .collect()
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -83,7 +83,7 @@ pub fn draw_ui<T: tui::backend::Backend>(
                 })
                 .collect();
 
-            let y_axis_bounds = data_store.y_axis_bounds();
+            let (y_axis_bounds, y_axis_num_ticks) = data_store.y_axis_bounds();
 
             let chart = Chart::new(datasets)
                 .block(Block::default().borders(Borders::NONE))
@@ -96,7 +96,7 @@ pub fn draw_ui<T: tui::backend::Backend>(
                     Axis::default()
                         .style(Style::default().fg(Color::Gray))
                         .bounds(y_axis_bounds)
-                        .labels(data_store.y_axis_labels(y_axis_bounds)),
+                        .labels(data_store.y_axis_labels(y_axis_bounds, y_axis_num_ticks)),
                 );
             f.render_widget(chart, chunks[args.cmds.len()]);
         })


### PR DESCRIPTION
Range is now chosen so that tick labels are guaranteed to be as close to the actual value they label as possible (the height of a terminal row being the limiting factor). Ticks are placed at multiples of 10^n * {1, 2, 5} so they are always round numbers.

The target number of ticks and the desired buffer at the top and bottom of the range in percent can be easily adjusted (in code).

Possible future work: Setting target tick count based on current height of terminal.

### Before:

![image](https://github.com/aantn/smag/assets/39708242/858bc570-05d0-41f7-9a22-8c547d739c4e)

### After:

![image](https://github.com/aantn/smag/assets/39708242/4b9b754e-e05e-4695-b6b1-6420c74ab2e7)

