### PR TITLE
Manually setting y-axis range

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,14 @@ pub struct Args {
     y_label: String,
 
     #[structopt(
+        short = "r",
+        long = "range",
+        default_value = "",
+        help = "Range (min, max) [and tick increment] of the y-axis (e.g. '0,100' or '-1,1,0.5')"
+    )]
+    manual_range: String,
+
+    #[structopt(
         short = "d",
         long = "diff",
         help = "Graph the diff of subsequent command outputs"

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -83,7 +83,31 @@ pub fn draw_ui<T: tui::backend::Backend>(
                 })
                 .collect();
 
-            let (y_axis_bounds, y_axis_num_ticks) = data_store.y_axis_bounds();
+            let (y_axis_bounds, y_axis_num_ticks) = if args.manual_range.is_empty() {
+                // Automatic range and tick placement algorithm
+                data_store.y_axis_bounds()
+            } else {
+                // User supplied range and possiby tick increment
+                let mut parts = args.manual_range.split(',');
+                let num_args = parts.clone().count();
+                if num_args != 2 && num_args != 3 {
+                    panic!("Invalid range format. Please use 'min,max' or 'min,max,increment'");
+                }
+
+                let min : f64 = parts.next().unwrap().parse().unwrap();
+                let max : f64 = parts.next().unwrap().parse().unwrap();
+                if min >= max {
+                    panic!("Invalid range format. Make sure min is less than max.");
+                }
+                let increment : f64 = if num_args == 3 {
+                    parts.next().unwrap().parse().unwrap()
+                } else {
+                    (max - min) / 4.0   // Default to targeting 5 ticks (= 4+1)
+                }.min(max - min);   // Make sure increment is not greater than range
+                let tick_count : i32 = ((max - min) / increment).round() as i32 + 1;
+
+                ([min, max], tick_count)
+            };
 
             let chart = Chart::new(datasets)
                 .block(Block::default().borders(Borders::NONE))


### PR DESCRIPTION
Added argument for setting y-axis range and tick increment.

User has to supply both minimum AND maximum.
Increment is optional; if not supplied, 5 ticks will be shown as default.

Closes #5