### PR TITLE
Y-axis tick spacing responsive to terminal height

### DIFF
--- a/src/datastore.rs
+++ b/src/datastore.rs
@@ -70,7 +70,7 @@ impl DataStore {
             self.window_max.iter().fold(0f64, |a, &b| a.max(b)),
         ]
     }
-    pub fn y_axis_bounds(&self) -> ([f64; 2], i32) {
+    pub fn y_axis_bounds(&self, chart_height: i32) -> ([f64; 2], i32) {
         let iter = self
             .data
             .iter()
@@ -82,20 +82,27 @@ impl DataStore {
         let range = max - min;
 
         // Parameters for automatic range and tick placement algorithm
-        let preferred_num_ticks : i32 = 5;
-        let range_buffer_percent_per_side : f64 = 5.0;
+        let range_buffer_percent_per_side = ((chart_height - 20).max(0) as f64 / 10.0).min(5.0);
+        let target_lines_per_tick = 7.0;
 
         // Calculate tick spacing by rounding the log10 of the preferred increment
-        let range_buffered = range + 2.0 * range_buffer_percent_per_side / 100.0;
-        let preferred_increment : f64 = range_buffered / (preferred_num_ticks - 1) as f64;
+        let range_buffered = if range != 0.0 {
+            range * (1.0 + 2.0 * range_buffer_percent_per_side / 100.0)
+        } else {
+            2.0
+        };
+        let target_num_ticks : f64 = ((chart_height - 1) as f64 / target_lines_per_tick).max(2.0);
+        let preferred_increment : f64 = range_buffered / target_num_ticks;
         let log10_times3 : i32 = (preferred_increment.log10() * 3.0).round() as i32;
         let exponent : i32 = log10_times3 / 3;
-        let mut increment : f64 = 10_f64.powf(exponent as f64).max(1.0);
+        let mut increment : f64 = 10_f64.powf(exponent as f64);
         // Adjust increment to a power-of-ten multiple of 1, 2 or 5
         match log10_times3 % 3 {
-            0 => (),
-            1 => increment *= 2.0,
-            2 => increment *= 5.0,
+            -2 => increment /= 5.0,
+            -1 => increment /= 2.0,
+             0 => (),
+             1 => increment *= 2.0,
+             2 => increment *= 5.0,
             _ => increment = 1.0,
         }
 
@@ -106,7 +113,12 @@ impl DataStore {
         let min_round = ((min - range_buffer_per_side) / increment).floor() * increment;
         let max_round = ((max + range_buffer_per_side) / increment).ceil()  * increment;
         // Calculate number of ticks
-        let num_ticks : i32 = ((max_round - min_round) / increment).round() as i32 + 1;
+        let mut num_ticks : i32 = ((max_round - min_round) / increment).round() as i32 + 1;
+        
+        if (((chart_height - 1) as f64 / num_ticks as f64)) < (0.3 * target_lines_per_tick) {
+            // Ticks are too close together, keep only min and max
+            num_ticks = 2;
+        }
 
         ([min_round, max_round], num_ticks)
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -83,9 +83,11 @@ pub fn draw_ui<T: tui::backend::Backend>(
                 })
                 .collect();
 
+            let chart_height = f.size().height as i32 - args.cmds.len() as i32 - 4;
+
             let (y_axis_bounds, y_axis_num_ticks) = if args.manual_range.is_empty() {
                 // Automatic range and tick placement algorithm
-                data_store.y_axis_bounds()
+                data_store.y_axis_bounds(chart_height)
             } else {
                 // User supplied range and possiby tick increment
                 let mut parts = args.manual_range.split(',');
@@ -102,11 +104,13 @@ pub fn draw_ui<T: tui::backend::Backend>(
                 let increment : f64 = if num_args == 3 {
                     parts.next().unwrap().parse().unwrap()
                 } else {
-                    (max - min) / 4.0   // Default to targeting 5 ticks (= 4+1)
+                    let target_lines_per_tick = 6.0;
+                    let target_num_ticks : f64 = (chart_height - 1) as f64 / target_lines_per_tick;
+                    (max - min) / target_num_ticks
                 }.min(max - min);   // Make sure increment is not greater than range
-                let tick_count : i32 = ((max - min) / increment).round() as i32 + 1;
+                let num_ticks : i32 = ((max - min) / increment).round() as i32 + 1;
 
-                ([min, max], tick_count)
+                ([min, max], num_ticks)
             };
 
             let chart = Chart::new(datasets)


### PR DESCRIPTION
Algorithm for tick increment now takes into account how much vertical space there currently is in the chart. The same goes for automatic tick increment for user-specified ranges.

If the chart is very shallow, the buffers at to and bottom are reduced and eventually removed and all ticks except min and max are dropped.

Also fixes automatic tick spacing for sub-1 ranges (hadn't tested that properly for previous PR, sorry about that).